### PR TITLE
Add TakeNext and TakePrevious methods for sequential source switching

### DIFF
--- a/scripts/Sourcerer.py
+++ b/scripts/Sourcerer.py
@@ -504,6 +504,40 @@ class Sourcerer(CallbacksExt):
         """Take the currently selected source."""
         self.Take(self.stored['SelectedSource']['index'])
 
+    def TakeNext(self, wrap=True):
+        """Take the source after the currently active source.
+
+        Args:
+            wrap: If True, wraps from last source back to first.
+        """
+        sources = self.stored['Sources']
+        if not sources:
+            return
+        active = self.stored['ActiveSource']['index']
+        if active == -1:
+            self.Take(0)
+        elif wrap:
+            self.Take((active + 1) % len(sources))
+        elif active + 1 < len(sources):
+            self.Take(active + 1)
+
+    def TakePrevious(self, wrap=True):
+        """Take the source before the currently active source.
+
+        Args:
+            wrap: If True, wraps from first source back to last.
+        """
+        sources = self.stored['Sources']
+        if not sources:
+            return
+        active = self.stored['ActiveSource']['index']
+        if active == -1:
+            self.Take(len(sources) - 1)
+        elif wrap:
+            self.Take((active - 1) % len(sources))
+        elif active - 1 >= 0:
+            self.Take(active - 1)
+
     def DelayTake(self, source, delay=0):
         """Take a source after a delay in frames."""
         run(self.Take, source, delayFrames=delay)


### PR DESCRIPTION
## Summary

- Adds `TakeNext(wrap=True)` and `TakePrevious(wrap=True)` methods to the `Sourcerer` class
- Both navigate relative to the currently **active** source (not the selection cursor)
- `wrap=True` (default) cycles the list end-to-end; `wrap=False` stops at the boundaries
- If no source is currently active (`index == -1`), `TakeNext` defaults to the first source and `TakePrevious` defaults to the last

## Motivation

Previously, taking the next or previous source required two steps: manually selecting it, then calling `TakeSelected`. These methods allow a single call for sequential switching, useful for keyboard shortcuts, source switching triggered by digital I/O, or any other remote trigger that would be a generic previous / next.